### PR TITLE
Non-breaking feature: ability to query spinner and set new title

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ Sets the default spinner string for all newly created instances. Accepts either 
 
 Sets the default spinner delay for all newly created instances.
 
+**`Spinner.setSpinnerTitle(spinnerTitle)`**
+
+Sets the spinner title. Use printf-style strings to position the spinner.
+
+**`Spinner.isSpinning()`**
+
+Returns true/false depending on whether the spinner is currently spinning.
+
 ##Demo
 
 To see a demonstration of the built-in spinners, point your console at the `example` folder and run:

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ Spinner.prototype.start = function() {
 };
 
 Spinner.prototype.isSpinning = function() {
-  return !!this.id;
+  return this.id === undefined;
 }
 
 Spinner.prototype.setSpinnerDelay = function(n) {

--- a/index.js
+++ b/index.js
@@ -52,14 +52,17 @@ Spinner.setDefaultSpinnerDelay = function(value) {
 Spinner.prototype.start = function() {
   var current = 0;
   var self = this;
-  var hasPos = self.text.indexOf('%s') > -1;
   this.id = setInterval(function() {
-    var msg = hasPos ? self.text.replace('%s', self.chars[current]) : self.chars[current] + ' ' + self.text;
+    var msg = self.text.indexOf('%s') > -1 ? self.text.replace('%s', self.chars[current]) : self.chars[current] + ' ' + self.text;
     clearLine();
     process.stdout.write(msg);
     current = ++current % self.chars.length;
   }, this.delay);
 };
+
+Spinner.prototype.isSpinning = function() {
+  return !!this.id;
+}
 
 Spinner.prototype.setSpinnerDelay = function(n) {
   this.delay = n;
@@ -69,8 +72,13 @@ Spinner.prototype.setSpinnerString = function(str) {
   this.chars = mapToSpinner(str, this.spinners).split('');
 };
 
+Spinner.prototype.setSpinnerTitle = function(str) {
+  this.text = str;
+}
+
 Spinner.prototype.stop = function(clear) {
   clearInterval(this.id);
+  this.id = undefined;
   if (clear) {
     clearLine();
   }
@@ -97,8 +105,8 @@ function mapToSpinner(value, spinners) {
 }
 
 function clearLine() {
-    readline.clearLine(process.stdout, 0);
-    readline.cursorTo(process.stdout, 0);
+  readline.clearLine(process.stdout, 0);
+  readline.cursorTo(process.stdout, 0);
 }
 
 exports.Spinner = Spinner;


### PR DESCRIPTION
I wanted to keep logging messages to the stdout while the spinner was spinning, to have a blanket logging method that looked something like:

```js
function log (msg) {
  if ( spinner && spinner.isSpinning() ) {
    spinner.setSpinnerTitle('%s' + msg);
  } else {
    console.log(msg);
  }
}
```

Obviously, in order to implement this I needed to fork and create the `setSpinnerTittle` and `isSpinning` methods. But i figured this might be a handy use for the whole community, so I've followed the same syntactic code style and wondering if you'd like to pull it into the master branch.

I wasn't sure what you'd want to do with the sem version, so I've left the package.json alone.

I'm using my fork in my project right now, but if you'll merge this pull request then I'll switch to using yours (then I can follow the project and get any other updates).