### PR TITLE
fix for isSpinning method

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ Spinner.prototype.start = function() {
 };
 
 Spinner.prototype.isSpinning = function() {
-  return this.id === undefined;
+  return this.id !== undefined;
 }
 
 Spinner.prototype.setSpinnerDelay = function(n) {


### PR DESCRIPTION
Apologies, the change from `!!this.id` to `this.id === undefined` was untested.

This fixes the problem so that `isSpinning` works as expected.

Thanks