### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Sets the spinner title. Use printf-style strings to position the spinner.
 
 Returns true/false depending on whether the spinner is currently spinning.
 
-##Demo
+## Demo
 
 To see a demonstration of the built-in spinners, point your console at the `example` folder and run:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
