### PR TITLE
Enable one-liner chaining by returning 'this' in function 'add'

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,8 @@ Spinner.prototype.start = function() {
 
     current = ++current % self.chars.length;
   }, this.delay);
+  
+  return this;
 };
 
 Spinner.prototype.isSpinning = function() {


### PR DESCRIPTION
```javascript
const spinner = new Spinner('%s do something').start();
```
instead of
```javascript
const spinner = new Spinner('%s do something');
spinner.start();
```