### PR TITLE
Fix `#setSpinnerTitle` docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ Starts the spinner.
 Stops the spinner. Accepts a Boolean parameter to clean the console.
 
 
+**`obj.isSpinning()`**
+
+Returns true/false depending on whether the spinner is currently spinning.
+
+
 **`obj.setSpinnerString(spinnerString)`**
 
 Sets the spinner string. Accepts either a String or an Integer index to reference the [built-in spinners](#demo).
@@ -63,6 +68,11 @@ Sets the spinner string. Accepts either a String or an Integer index to referenc
 Sets the spinner animation speed.
 
 
+**`obj.setSpinnerTitle(spinnerTitle)`**
+
+Sets the spinner title. Use printf-style strings to position the spinner.
+
+
 **`Spinner.setDefaultSpinnerString(spinnerString)`**
 
 Sets the default spinner string for all newly created instances. Accepts either a String or an Integer index to reference the [built-in spinners](#demo).
@@ -71,16 +81,6 @@ Sets the default spinner string for all newly created instances. Accepts either 
 **`Spinner.setDefaultSpinnerDelay(spinnerDelay)`**
 
 Sets the default spinner delay for all newly created instances.
-
-
-**`Spinner.setSpinnerTitle(spinnerTitle)`**
-
-Sets the spinner title. Use printf-style strings to position the spinner.
-
-
-**`Spinner.isSpinning()`**
-
-Returns true/false depending on whether the spinner is currently spinning.
 
 ## Demo
 


### PR DESCRIPTION
The README states that `setSpinnerTitle` and `isSpinning` are on the `Spinner` object, whereas it's actually on [`Spinner.prototype`](https://github.com/helloIAmPau/node-spinner/blob/master/index.js#L65).