### PR TITLE
Output to stderr by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ var Spinner = function(options){
   this.setSpinnerString(defaultSpinnerString);
   this.setSpinnerDelay(defaultSpinnerDelay);
   this.onTick = options.onTick || defaultOnTick;
-  this.stream = options.stream || process.stdout;
+  this.stream = options.stream || process.stderr;
 };
 
 Spinner.spinners = require('./spinners.json');


### PR DESCRIPTION
Sending the spinner to stdout does not make sense since it pollutes it.

Effectively making pipes unusable.

e.g.: node index.js > noisy-file.txt

The file would be filled with noise. While the library allows you to set the
stream (#14), it makes much more sense to use stderr should be the default.